### PR TITLE
Fix changing url bug(#52)

### DIFF
--- a/client/vendor/page.js
+++ b/client/vendor/page.js
@@ -135,7 +135,7 @@
     if (!dispatch) return;
     var url = (hashbang && ~location.hash.indexOf('#!'))
       ? location.hash.substr(2) + location.search
-      : location.pathname + location.search + location.hash;
+      : location.href.replace(location.origin, "");
     page.replace(url, null, true, dispatch);
   };
 
@@ -308,7 +308,6 @@
    */
 
   function Context(path, state) {
-    path = decodeURLEncodedURIComponent(path);
     if ('/' === path[0] && 0 !== path.indexOf(base)) path = base + path;
     var i = path.indexOf('?');
 


### PR DESCRIPTION
#52 Because Router shouldn't change url.

## What I did
* I think router dosen't need to decodeURI, So I remove this function.
* Change  `location.pathname + location.search + location.hash ` -> `location.href.replace(location.origin, "")`

## How to test
* Input url with query like `/foo?`, `/foo?a%26b=c&d=e` and see whether it’s changed

Tested: Safari, Chrome, Fire Fox on mac