### PR TITLE
[WIP] Add group routes support

### DIFF
--- a/client/group.js
+++ b/client/group.js
@@ -1,0 +1,49 @@
+Group = function(router, options, parent) {
+  options = options || {};
+
+  if (options.prefix && !/^\/.*/.test(options.prefix)) {
+    var message = "group's prefix must start with '/'";
+    throw new Error(message);
+  }
+
+  this._router = router;
+  this.prefix = options.prefix || '';
+
+  this._middlewares = options.middlewares || [];
+  this._subscriptions = options.subscriptions || Function.prototype;
+
+  this.parent = parent;
+  if (this.parent) {
+    this.prefix = parent.prefix + this.prefix;
+    this._middlewares = parent._middlewares.concat(this._middlewares);
+  }
+};
+
+Group.prototype.route = function(path, options, group) {
+  options = options || {};
+
+  if (!/^\/.*/.test(path)) {
+    var message = "route's path must start with '/'";
+    throw new Error(message);
+  }
+
+  group = group || this;
+  path = this.prefix + path;
+
+  var middlewares = options.middlewares || [];
+  options.middlewares = this._middlewares.concat(middlewares);
+
+  return this._router.route(path, options, group);
+};
+
+Group.prototype.group = function(options) {
+  return new Group(this._router, options, this);
+};
+
+Group.prototype.callSubscriptions = function(current) {
+  if (this.parent) {
+    this.parent.callSubscriptions(current);
+  }
+
+  this._subscriptions.call(current.route, current.params, current.queryParams);
+};

--- a/client/route.js
+++ b/client/route.js
@@ -1,4 +1,4 @@
-Route = function(router, path, options) {
+Route = function(router, path, options, group) {
   options = options || {};
 
   this.path = path;
@@ -11,6 +11,8 @@ Route = function(router, path, options) {
   this._middlewares = options.middlewares || [];
   this._subsMap = {};
   this._router = router;
+
+  this.group = group;
 };
 
 Route.prototype.clearSubscriptions = function() {
@@ -62,5 +64,9 @@ Route.prototype.callAction = function(current) {
 
 Route.prototype.callSubscriptions = function(current) {
   this.clearSubscriptions();
+  if (this.group) {
+    this.group.callSubscriptions(current);
+  }
+
   this._subscriptions(current.params, current.queryParams);
 };

--- a/client/router.js
+++ b/client/router.js
@@ -20,10 +20,15 @@ Router = function () {
   this.safeToRun = false;
 };
 
-Router.prototype.route = function(path, options) {
+Router.prototype.route = function(path, options, group) {
+  if (!/^\/.*/.test(path)) {
+    var message = "route's path must start with '/'";
+    throw new Error(message);
+  }
+
   options = options || {};
   var self = this;
-  var route = new Route(this, path, options);
+  var route = new Route(this, path, options, group);
 
   route._handler = function (context, next) {
     self._current = {
@@ -45,6 +50,10 @@ Router.prototype.route = function(path, options) {
   this._updateCallbacks();
 
   return route;
+};
+
+Router.prototype.group = function(options) {
+  return new Group(this, options);
 };
 
 Router.prototype.path = function(pathDef, fields, queryParams) {

--- a/package.js
+++ b/package.js
@@ -17,9 +17,11 @@ Package.onUse(function(api) {
   api.addFiles('client/vendor/page.js', 'client');
   api.addFiles('client/vendor/query.js', 'client');
   api.addFiles('client/router.js', 'client');
+  api.addFiles('client/group.js', 'client');
   api.addFiles('client/route.js', 'client');
   api.addFiles('client/_init.js', 'client');
   api.addFiles('server/router.js', 'server');
+  api.addFiles('server/group.js', 'server');
   api.addFiles('server/route.js', 'server');
   api.addFiles('server/_init.js', 'server');
 
@@ -42,4 +44,6 @@ Package.onTest(function(api) {
   api.addFiles('test/client/router.naming.spec.js', 'client');
   api.addFiles('test/client/route.test.js', 'client');
   api.addFiles('test/client/route.spec.js', 'client');
+
+  api.addFiles('test/client/group.spec.js', 'client');
 });

--- a/server/group.js
+++ b/server/group.js
@@ -1,0 +1,18 @@
+Group = function(router, options) {
+  options = options || {};
+  this.prefix = options.prefix || '';
+
+  this._router = router;
+};
+
+Group.prototype.route = function(path, options) {
+  path = this.prefix + path;
+  return this._router.route(path, options);
+};
+
+Group.prototype.group = function(options) {
+  var group = new Group(this._router, options);
+  group.parent = this;
+
+  return group;
+};

--- a/server/router.js
+++ b/server/router.js
@@ -1,12 +1,16 @@
 Router = function () {
-  this._routeMap = {};
+  this._routesMap = {};
   this.subscriptions = Function.prototype;
 };
 
 
 Router.prototype.route = function(path, options) {
-  this._routeMap[path] = new Route(this, path, options);
-  return this._routeMap[path];
+  this._routesMap[path] = new Route(this, path, options);
+  return this._routesMap[path];
+};
+
+Router.prototype.group = function(path, options) {
+  return new Group(this, options);
 };
 
 

--- a/test/client/group.spec.js
+++ b/test/client/group.spec.js
@@ -1,0 +1,113 @@
+Tinytest.add('Client - Group - validate path definition', function (test, next) {
+  // path & prefix must start with '/'
+  test.throws(function() {
+    new Group(null, {prefix: Random.id()});
+  });
+
+  var group = FlowRouter.group({prefix: '/' + Random.id()});
+
+  test.throws(function() {
+    group.route(Random.id());
+  });
+});
+
+Tinytest.addAsync('Client - Group - define and go to route with prefix', function (test, next) {
+  var prefix = Random.id();
+  var rand = Random.id();
+  var rendered = 0;
+
+  var group = FlowRouter.group({prefix: '/' + prefix});
+
+  group.route('/' + rand, {
+    action: function(_params) {
+      rendered++;
+    }
+  });
+
+  FlowRouter.go('/' + prefix + '/' + rand);
+
+  setTimeout(function() {
+    test.equal(rendered, 1);
+    setTimeout(next, 100);
+  }, 100);
+});
+
+Tinytest.addAsync('Client - Group - define and go to route without prefix', function (test, next) {
+  var rand = Random.id();
+  var rendered = 0;
+
+  var group = FlowRouter.group();
+
+  group.route('/' + rand, {
+    action: function(_params) {
+      rendered++;
+    }
+  });
+
+  FlowRouter.go('/' + rand);
+
+  setTimeout(function() {
+    test.equal(rendered, 1);
+    setTimeout(next, 100);
+  }, 100);
+});
+
+Tinytest.addAsync('Client - Group - add middleware', function (test, next) {
+  var rand = Random.id(), rand2 = Random.id();
+  var log = [];
+  var paths = ['/' + rand2, '/' + rand];
+  var done = false;
+
+  var middleFn = function (path, next) {
+    if(done) return next();
+    test.equal(path, paths.pop());
+    log.push(0);
+    next();
+  };
+
+  var group = FlowRouter.group({
+    middlewares: [middleFn]
+  });
+
+  group.route('/' + rand, {
+    action: function(_params) {
+      log.push(1);
+    }
+  });
+
+  group.route('/' + rand2, {
+    action: function(_params) {
+      log.push(2);
+    }
+  });
+
+  FlowRouter.go('/' + rand);
+
+  setTimeout(function() {
+    FlowRouter.go('/' + rand2);
+
+    setTimeout(function() {
+      test.equal(log, [0, 1, 0, 2]);
+      done = true;
+      setTimeout(next, 100);
+    }, 100);
+  }, 100);
+});
+
+Tinytest.addAsync('Client - Group - subscribe', function (test, next) {
+  var rand = Random.id();
+
+  var group = FlowRouter.group({
+    subscriptions: function (params) {
+      this.register('baz', Meteor.subscribe('baz'));
+    }
+  });
+
+  group.route('/' + rand);
+
+  FlowRouter.go('/' + rand);
+  setTimeout(function() {
+    test.isTrue(!!GetSub('baz'));
+    next();
+  }, 100);
+});

--- a/test/client/router.spec.js
+++ b/test/client/router.spec.js
@@ -1,4 +1,12 @@
 Router = FlowRouter.Router;
+
+Tinytest.add('Client - Router - validate path definition', function (test, next) {
+  // path must start with '/'
+  test.throws(function() {
+    FlowRouter.route(Random.id());
+  });
+});
+
 Tinytest.addAsync('Client - Router - define and go to route', function (test, next) {
   var rand = Random.id();
   var rendered = 0;


### PR DESCRIPTION
```js
var group = FlowRouter.group({
  prefix: '/admin',
  middlewares: [
    function(path, next) {
      console.log('running group middleware');
      next();
    }
  ]
});

group.route('', {
  action: function() {
    FlowLayout.render('componentLayout', {content: 'admin'});
  },
  middlewares: [
    function(path, next) {
      console.log('running /admin middleware');
      next();
    }
  ]
});

group.route('/posts', {
  action: function() {
    FlowLayout.render('componentLayout', {content: 'posts'});
  }
});
```

PS: If someone has better implementation than mine, feel free to create another PR. I'll close it and let's workon yours. 