### PR TITLE
Don't re route when path haven't changed.

### DIFF
--- a/client/router.js
+++ b/client/router.js
@@ -74,7 +74,10 @@ Router.prototype.path = function(pathDef, fields, queryParams) {
 
 Router.prototype.go = function(pathDef, fields, queryParams) {
   var path = this.path(pathDef, fields, queryParams);
-  this._page(path);
+
+  if (this._current.path !== path) {
+    this._page(path);
+  }
 };
 
 Router.prototype.redirect = function(path) {


### PR DESCRIPTION
Setting same params/queryParams with current route, causes re route. But it isn't necessary.