### PR TITLE
fix bug in server-side 'group' definition

### DIFF
--- a/server/router.js
+++ b/server/router.js
@@ -9,7 +9,7 @@ Router.prototype.route = function(path, options) {
   return this._routesMap[path];
 };
 
-Router.prototype.group = function(path, options) {
+Router.prototype.group = function(options) {
   return new Group(this, options);
 };
 


### PR DESCRIPTION
In the docs, FlowRouter.group has only one options argument, but on the server it is created with 2 : 'path' and 'options'. By getting rid of the path argument, we get the expected behaviour on the server.