### PR TITLE
Fix triggers loading bug

### DIFF
--- a/client/router.js
+++ b/client/router.js
@@ -452,7 +452,7 @@ Router.prototype._initTriggersAPI = function() {
   this.triggers = {
     enter: function(triggers, filter) {
       triggers = Triggers.applyFilters(triggers, filter);
-      _.extend(self._triggersEnter, triggers);
+      self._triggersEnter = self._triggersEnter.concat(triggers);
     },
 
     exit: function(triggers, filter) {

--- a/client/router.js
+++ b/client/router.js
@@ -452,12 +452,12 @@ Router.prototype._initTriggersAPI = function() {
   this.triggers = {
     enter: function(triggers, filter) {
       triggers = Triggers.applyFilters(triggers, filter);
-      self._triggersEnter = self._triggersEnter.concat(triggers);
+      if(triggers.length) self._triggersEnter = self._triggersEnter.concat(triggers);
     },
 
     exit: function(triggers, filter) {
       triggers = Triggers.applyFilters(triggers, filter);
-      _.extend(self._triggersExit, triggers);
+      if(triggers.length) self._triggersExit = self._triggersExit.concat(triggers);
     }
   };
 };

--- a/client/router.js
+++ b/client/router.js
@@ -452,12 +452,16 @@ Router.prototype._initTriggersAPI = function() {
   this.triggers = {
     enter: function(triggers, filter) {
       triggers = Triggers.applyFilters(triggers, filter);
-      if(triggers.length) self._triggersEnter = self._triggersEnter.concat(triggers);
+      if(triggers.length) {
+        self._triggersEnter = self._triggersEnter.concat(triggers);
+      }
     },
 
     exit: function(triggers, filter) {
       triggers = Triggers.applyFilters(triggers, filter);
-      if(triggers.length) self._triggersExit = self._triggersExit.concat(triggers);
+      if(triggers.length) {
+        self._triggersExit = self._triggersExit.concat(triggers);
+      }
     }
   };
 };


### PR DESCRIPTION
This fixes a bug where multiple global enter/exit triggers are overwritten and not concatenated. 
Eg if I do

FlowRouter.triggers.enter([fooTrigger]);
FlowRouter.triggers.enter([barTrigger]);

only barTrigger will show up in FlowRouter._triggersEnter array